### PR TITLE
Refactor GCP to use sub sub command

### DIFF
--- a/cli/gcp.go
+++ b/cli/gcp.go
@@ -52,7 +52,16 @@ func newGCPBQCmd() cli.Command {
 		Name:    "biqquery",
 		Aliases: []string{"bq"},
 		Usage:   "Open Bigquery page",
-		Flags:   []cli.Flag{},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "database",
+				Usage: "Database to show",
+			},
+			cli.StringFlag{
+				Name:  "table",
+				Usage: "Table to show",
+			},
+		},
 		Action: func(c *cli.Context) error {
 			gcp := &gcp.Provider{}
 			return browser.Open(c, gcp)
@@ -65,7 +74,16 @@ func newGCPGKECmd() cli.Command {
 		Name:    "kubernetes",
 		Aliases: []string{"gke"},
 		Usage:   "Open GKE page",
-		Flags:   []cli.Flag{},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "region",
+				Usage: "Region of the cluster",
+			},
+			cli.StringFlag{
+				Name:  "name",
+				Usage: "Name of the cluter",
+			},
+		},
 		Action: func(c *cli.Context) error {
 			gcp := &gcp.Provider{}
 			return browser.Open(c, gcp)

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -103,7 +103,23 @@ func (p *Provider) addProductPath(product string) {
 	switch product {
 	case "appengine":
 	case "bigquery":
+		var db, table string
+		if db = p.Ctx.String("database"); db != "" {
+			param := url.Values{}
+			param.Add("d", db)
+			if table = p.Ctx.String("table"); table != "" {
+				param.Add("t", table)
+			}
+			p.URL.RawQuery = param.Encode()
+		}
 	case "kubernetes":
+		var region, name string
+		if region = p.Ctx.String("region"); region != "" {
+			p.join(fmt.Sprintf("details/%s", region))
+			if name = p.Ctx.String("name"); name != "" {
+				p.join(name)
+			}
+		}
 	case "spanner":
 		var instance, db, scheme string
 		if instance = p.Ctx.String("instance"); instance != "" {


### PR DESCRIPTION
## What

* Example: `biko gcp --product spanner` -> `biko gcp spanner`

## Why

* Like as `gcloud` command