### PR TITLE
Fix go get cmd in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ $ brew install biko
 Install by source code.
 
 ```
-$ go get github.com/KeisukeYamashita/biko
+$ go get github.com/KeisukeYamashita/biko/cmd/biko
 ```
 
 Then build it.


### PR DESCRIPTION
## What
-> `go get github.com/KeisukeYamashita/biko/cmd/biko`

## Why
```
$ go get github.com/KeisukeYamashita/biko
can't load package: package github.com/KeisukeYamashita/biko: no Go files in /hoge/go/src/github.com/KeisukeYamashita/biko
```