### PR TITLE
Fix datadog provider

### DIFF
--- a/providers/datadog/datadog.go
+++ b/providers/datadog/datadog.go
@@ -74,7 +74,7 @@ func (p *Provider) join(additionPath string) {
 
 // GetCtxString ...
 func (p *Provider) GetCtxString(str string) string {
-	key := p.GetCtxString(str)
+	key := p.Ctx.String(str)
 	if key == "" {
 		return ""
 	}

--- a/providers/datadog/datadog.go
+++ b/providers/datadog/datadog.go
@@ -1,4 +1,4 @@
-package gcp
+package datadog
 
 import (
 	"net/url"


### PR DESCRIPTION
## What
- Rename package name: gcp -> datadog
- Fix `GetCtxString`

## Why
Because `GetCtxString` is being circularly referenced, a stack overflow will probably occur.