### PR TITLE
Add saved_view param in datadog logs

### DIFF
--- a/cli/datadog.go
+++ b/cli/datadog.go
@@ -152,7 +152,12 @@ func newDDLogsCmd() cli.Command {
 	return cli.Command{
 		Name:  "logs",
 		Usage: "Open Logs page",
-		Flags: []cli.Flag{},
+		Flags: []cli.Flag{
+			cli.StringFlag{
+				Name:  "view",
+				Usage: "Specify the saved view to open",
+			},
+		},
 		Action: func(c *cli.Context) error {
 			dd, err := dd.GetProvider()
 			if err != nil {

--- a/providers/datadog/datadog.go
+++ b/providers/datadog/datadog.go
@@ -58,6 +58,12 @@ func (p *Provider) addProductPath(product string) {
 	case "apm":
 	case "notebook":
 	case "logs":
+		var view string
+		if view = p.GetCtxString("view"); view != "" {
+			param := url.Values{}
+			param.Add("saved_view", view)
+			p.URL.RawQuery = param.Encode()
+		}
 	case "synthetics":
 	default:
 		p.join("apm/home")


### PR DESCRIPTION
## What
Add view flag to specify the saved view to open.

Example:
`$ biko dd logs --view 1` -> open `https://app.datadoghq.com/logs?saved_view=1`

## Why
Because I want to use it.