### PR TITLE
Add short arg of view in datadog

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $ biko dd [product] [flag(s)]
 | Integrations | Go to Integrations page | `integrations` | - |
 | APM | Go to APM page | `apm` | - |
 | Notebook | Go to Notebook page | `notebook` | - | 
-| Logs | Go to logs page | `logs` | - | 
+| Logs | Go to logs page | `logs` | `--view, -v` |
 | Synthetics | Go to synthetics page | `synthetics` | - |
 
 ### Google

--- a/cli/datadog.go
+++ b/cli/datadog.go
@@ -154,7 +154,7 @@ func newDDLogsCmd() cli.Command {
 		Usage: "Open Logs page",
 		Flags: []cli.Flag{
 			cli.StringFlag{
-				Name:  "view",
+				Name:  "view, v",
 				Usage: "Specify the saved view to open",
 			},
 		},


### PR DESCRIPTION
## What
- Add short arg of view in datadog
- Update readme

Example:
`biko dd logs -v 1` -> open `https://app.datadoghq.com/logs?saved_view=1`

## Why
- To make it more convenient
- Update information