### PR TITLE
🍉 add goreleaser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,11 @@ jobs:
             name: Run Test
             command: |
               go test ./...
+  release:
+    executor: default
+    steps:
+      - checkout
+      - run: curl -sL https://git.io/goreleaser | bash
 
 workflows:
   version: 2
@@ -32,3 +37,11 @@ workflows:
     jobs:
       - build
       - test
+  release:
+    jobs:
+      - release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*(-.*)*/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,37 @@
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    ldflags:
+      - -X main.Version={{ .Version }}
+checksum:
+  name_template: '{{ .ProjectName }}_checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - Merge pull request
+      - Merge branch
+brew:
+  github:
+    owner: KeisukeYamashita
+    name: homebrew-biko
+  homepage:  https://github.com/KeisukeYamashita/biko
+  description: CLI tool to jump to your browser directly to improve productivity
+  test: |
+    system "#{bin}/biko -v"


### PR DESCRIPTION
## What

Introduced [GoReleaser](https://goreleaser.com/).

## Why

GoReleaser automatically releases a binary to GitHub Releases and updates Homebrew formula when a tag has pushed.