### PR TITLE
fix datadog example usage on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ If you don't specify the project, it will use the value configured by `gcloud` S
 #### Example2. Open Datadog Dashboad 
 
 ```
-$ biko dd --dashboard DASHBOARD_ID
+$ biko dd dashboard
 ```
 
 ## Alias 


### PR DESCRIPTION
## What

I fixed datadog usage on README.md

## Why

Datadog subcommand accepts "subsub"-command, not flags.

In current implementation, the subcommand does not accepts `dashboard id`, too. 