### PR TITLE
support jira self-managed plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,7 @@ $ biko yt [product] [flag(s)]
 ### JIRA
 
 * If you are using SSO, you need to pass `--org` or configure `BIKO_JIRA`
+* If you are using Jira self-managed plan, you need to specify base URL by passing `--base` or setting `BIKO_JIRA_BASE`
 * This `--project` flag can be omitted by set `BIKO_JIRA_PROJECT` to the env variable
 
 ```

--- a/cli/jira.go
+++ b/cli/jira.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/KeisukeYamashita/biko/browser"
 	jr "github.com/KeisukeYamashita/biko/providers/jira"
@@ -34,14 +35,20 @@ func newJIRACmd() cli.Command {
 				EnvVar: "BIKO_JIRA",
 				Usage:  "Specify JIRA Organization",
 			},
+			cli.StringFlag{
+				Name:   "base",
+				EnvVar: "BIKO_JIRA_BASE",
+				Usage:  "Specify JIRA Base URL (for self-managed plan)",
+			},
 		},
 		Action: func(c *cli.Context) error {
-			var org string
-			if org = c.String("org"); org == "" {
-				return fmt.Errorf("Org for jira not configured pass --org or set BIKO_JIRA")
+			baseURL, err := getBaseURL(c)
+			if err != nil {
+				return err
 			}
-			jr := &jr.Provider{
-				Org: org,
+			jr := &jr.Provider{}
+			if jr.BaseURL, err = url.Parse(baseURL); err != nil {
+				return err
 			}
 			return browser.Open(c, jr)
 		},
@@ -67,14 +74,20 @@ func newJIRADashboardCmd() cli.Command {
 				EnvVar: "BIKO_JIRA",
 				Usage:  "Specify JIRA Organization",
 			},
+			cli.StringFlag{
+				Name:   "base",
+				EnvVar: "BIKO_JIRA_BASE",
+				Usage:  "Specify JIRA Base URL (for self-managed plan)",
+			},
 		},
 		Action: func(c *cli.Context) error {
-			var org string
-			if org = c.String("org"); org == "" {
-				return fmt.Errorf("Org for jira not configured pass --org or set BIKO_JIRA")
+			baseURL, err := getBaseURL(c)
+			if err != nil {
+				return err
 			}
-			jr := &jr.Provider{
-				Org: org,
+			jr := &jr.Provider{}
+			if jr.BaseURL, err = url.Parse(baseURL); err != nil {
+				return err
 			}
 			return browser.Open(c, jr)
 		},
@@ -92,14 +105,20 @@ func newJIRAProjectsCmd() cli.Command {
 				EnvVar: "BIKO_JIRA",
 				Usage:  "Specify JIRA Organization",
 			},
+			cli.StringFlag{
+				Name:   "base",
+				EnvVar: "BIKO_JIRA_BASE",
+				Usage:  "Specify JIRA Base URL (for self-managed plan)",
+			},
 		},
 		Action: func(c *cli.Context) error {
-			var org string
-			if org = c.String("org"); org == "" {
-				return fmt.Errorf("Org for jira not configured pass --org or set BIKO_JIRA")
+			baseURL, err := getBaseURL(c)
+			if err != nil {
+				return err
 			}
-			jr := &jr.Provider{
-				Org: org,
+			jr := &jr.Provider{}
+			if jr.BaseURL, err = url.Parse(baseURL); err != nil {
+				return err
 			}
 			return browser.Open(c, jr)
 		},
@@ -117,14 +136,20 @@ func newJIRAPeopleCmd() cli.Command {
 				EnvVar: "BIKO_JIRA",
 				Usage:  "Specify JIRA Organization",
 			},
+			cli.StringFlag{
+				Name:   "base",
+				EnvVar: "BIKO_JIRA_BASE",
+				Usage:  "Specify JIRA Base URL (for self-managed plan)",
+			},
 		},
 		Action: func(c *cli.Context) error {
-			var org string
-			if org = c.String("org"); org == "" {
-				return fmt.Errorf("Org for jira not configured pass --org or set BIKO_JIRA")
+			baseURL, err := getBaseURL(c)
+			if err != nil {
+				return err
 			}
-			jr := &jr.Provider{
-				Org: org,
+			jr := &jr.Provider{}
+			if jr.BaseURL, err = url.Parse(baseURL); err != nil {
+				return err
 			}
 			return browser.Open(c, jr)
 		},
@@ -142,14 +167,20 @@ func newJIRAIssuesCmd() cli.Command {
 				EnvVar: "BIKO_JIRA",
 				Usage:  "Specify JIRA Organization",
 			},
+			cli.StringFlag{
+				Name:   "base",
+				EnvVar: "BIKO_JIRA_BASE",
+				Usage:  "Specify JIRA Base URL (for self-managed plan)",
+			},
 		},
 		Action: func(c *cli.Context) error {
-			var org string
-			if org = c.String("org"); org == "" {
-				return fmt.Errorf("Org for jira not configured pass --org or set BIKO_JIRA")
+			baseURL, err := getBaseURL(c)
+			if err != nil {
+				return err
 			}
-			jr := &jr.Provider{
-				Org: org,
+			jr := &jr.Provider{}
+			if jr.BaseURL, err = url.Parse(baseURL); err != nil {
+				return err
 			}
 			return browser.Open(c, jr)
 		},
@@ -172,14 +203,20 @@ func newJIRABacklogCmd() cli.Command {
 				EnvVar: "BIKO_JIRA",
 				Usage:  "Specify JIRA Organization",
 			},
+			cli.StringFlag{
+				Name:   "base",
+				EnvVar: "BIKO_JIRA_BASE",
+				Usage:  "Specify JIRA Base URL (for self-managed plan)",
+			},
 		},
 		Action: func(c *cli.Context) error {
-			var org string
-			if org = c.String("org"); org == "" {
-				return fmt.Errorf("Org for jira not configured pass --org or set BIKO_JIRA")
+			baseURL, err := getBaseURL(c)
+			if err != nil {
+				return err
 			}
-			jr := &jr.Provider{
-				Org: org,
+			jr := &jr.Provider{}
+			if jr.BaseURL, err = url.Parse(baseURL); err != nil {
+				return err
 			}
 			return browser.Open(c, jr)
 		},
@@ -202,19 +239,39 @@ func newJIRAReportsCmd() cli.Command {
 				EnvVar: "BIKO_JIRA",
 				Usage:  "Specify JIRA Organization",
 			},
+			cli.StringFlag{
+				Name:   "base",
+				EnvVar: "BIKO_JIRA_BASE",
+				Usage:  "Specify JIRA Base URL (for self-managed plan)",
+			},
 		},
 		Action: func(c *cli.Context) error {
-			var project, org string
+			var project string
 			if project = c.String("project"); project == "" {
 				return fmt.Errorf("Project for jira not configured pass --project or set BIKO_JIRA_PROJECT")
 			}
-			if org = c.String("org"); org == "" {
-				return fmt.Errorf("Org for jira not configured pass --org or set BIKO_JIRA")
+			baseURL, err := getBaseURL(c)
+			if err != nil {
+				return err
 			}
-			jr := &jr.Provider{
-				Org: org,
+			jr := &jr.Provider{}
+			if jr.BaseURL, err = url.Parse(baseURL); err != nil {
+				return err
 			}
 			return browser.Open(c, jr)
 		},
 	}
+}
+
+func getBaseURL(c *cli.Context) (string, error) {
+	org := c.String("org")
+	base := c.String("base")
+	if org == "" && base == "" {
+		return "", fmt.Errorf("Org and Base for jira not configured pass --org/BIKO_JIRA or --base/BIKO_JIRA_BASE")
+	}
+	var baseURL = fmt.Sprintf("https://%s.atlassian.net", org) // for jira cloud
+	if base != "" {
+		baseURL = base // for self-managed
+	}
+	return baseURL, nil
 }

--- a/providers/jira/jira.go
+++ b/providers/jira/jira.go
@@ -25,10 +25,9 @@ import (
 
 // Provider ...
 type Provider struct {
-	baseURL *url.URL
+	BaseURL *url.URL
 	URL     *url.URL
 	Ctx     *cli.Context
-	Org     string
 	Aliases map[string]interface{}
 }
 
@@ -52,12 +51,6 @@ func (p *Provider) Init(c *cli.Context) error {
 
 // GetTargetURL ...
 func (p *Provider) GetTargetURL() (string, error) {
-	var baseURL = fmt.Sprintf("https://%s.atlassian.net", p.Org)
-	var err error
-	if p.baseURL, err = url.Parse(baseURL); err != nil {
-		return "", err
-	}
-
 	p.addProductPath(p.Ctx.Command.Name)
 	return p.URL.String(), nil
 }
@@ -89,7 +82,7 @@ func (p *Provider) addProductPath(product string) {
 
 func (p *Provider) join(additionPath string) {
 	if p.URL == nil {
-		p.URL = p.baseURL
+		p.URL = p.BaseURL
 	}
 	p.URL.Path = path.Join(p.URL.Path, additionPath)
 }


### PR DESCRIPTION
## What

support using base URL for Jira [self-managed plan](https://www.atlassian.com/software/jira/pricing?tab=self-managed)

## Why

If the user uses self-managed plan, the base URL of Jira is different from cloud plan (not https://[organization].atlassian.net/).

I added `--base` option to specify base URL.


## Usage

```bash
$ biko jira is --base https://jira.example.com/
// will open https://jira.example.com/issues
```
