### PR TITLE
Upgrade Go to 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - uses: goreleaser/goreleaser-action@v2
         with:
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
       - run: go test -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Go Server Binary
-FROM golang:1.13
+FROM golang:1.16
 LABEL MAINTAINER=KeisukeYamashita
 
 ENV GO111MODULE on

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ Biko is released under the Apache License 2.0.
 
 <!-- badge links -->
 [go]: https://golang.org/dl
-[go-badge]: https://img.shields.io/badge/Go-1.13-blue
+[go-badge]: https://img.shields.io/badge/Go-1.16-blue
 
 [godoc]: https://godoc.org/github.com/KeisukeYamashita/biko
 [godoc-badge]: https://img.shields.io/badge/godoc.org-reference-blue.svg

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,4 @@ require (
 	gopkg.in/ini.v1 v1.48.0 // indirect
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
## Why 

To maintain the project. 
Upload to the latest Go version.

Also https://github.com/KeisukeYamashita/biko/issues/109.